### PR TITLE
get db_init to wait for postgres to be up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,7 @@ services:
     image: data61/anonlink-encoding-service:latest
     environment:
      - CLKHASH_SERVICE_DB_URI=postgresql://postgres:secret@postgres:5432/postgres
-    entrypoint:
-     - python3
-     - database.py
-     - init
+    entrypoint: /bin/sh -c "dockerize -wait tcp://postgres:5432 python3 database.py init"
     depends_on:
       - postgres
 


### PR DESCRIPTION
The way the docker-compose file was written is very fragile. 
The `encoding_db_init` service could start before the postgres db was fully up, thus, the db initialization could fail.

As the anonlink base image already includes dockerize, we can use that to wait for postgres db to be ready.