### PR TITLE
Update k8s deployment

### DIFF
--- a/k8s-deployment/encoding-service/Chart.yaml
+++ b/k8s-deployment/encoding-service/Chart.yaml
@@ -1,6 +1,7 @@
 name: encoding-service
 description: A service for encoding PII into CLKs.
-version: 0.0.2
+version: 0.0.3
+apiVersion: v1
 keywords:
   - clks
 sources:

--- a/k8s-deployment/encoding-service/requirements.yaml
+++ b/k8s-deployment/encoding-service/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 1.0.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 8.9.1
+    repository: https://charts.bitnami.com/bitnami
     condition: provision.postgresql

--- a/k8s-deployment/encoding-service/templates/_helpers.tpl
+++ b/k8s-deployment/encoding-service/templates/_helpers.tpl
@@ -24,13 +24,14 @@ Define the database URI because we need it in a few places.
 {{/* We define the release labels that will be applied to all deployments. */}}
 {{- define "release_labels" }}
 app: {{ template "fullname" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-# The "heritage" label is used to track which tool deployed a given chart.
+app.kubernetes.io/name: {{ template "fullname" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+# The "managed-by" label is used to track which tool deployed a given chart.
 # It is useful for admins who want to see what releases a particular tool
 # is responsible for.
-heritage: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 version: {{ .Chart.Version | quote }}
-# The "release" convention makes it easy to tie a release to all of the
+# The "instance" convention makes it easy to tie a release to all of the
 # Kubernetes resources that were created as part of that release.
-release: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/k8s-deployment/encoding-service/templates/encoding-app-deployment.yaml
+++ b/k8s-deployment/encoding-service/templates/encoding-app-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.app.replicas}}
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: encoding-app
   template:
     metadata:

--- a/k8s-deployment/encoding-service/templates/encoding-app-service.yaml
+++ b/k8s-deployment/encoding-service/templates/encoding-app-service.yaml
@@ -1,18 +1,30 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     {{- include "release_labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{- toYaml .Values.service.labels | nindent 4 }}
+{{- end }}
   name: encoding-app
 spec:
   type: {{ .Values.service.type }}
-  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
-  - name: "http"
-    port: {{ .Values.service.port }}
+  - name: http
+    port: {{ .Values.service.servicePort }}
     targetPort: encodingservice
   selector:
     component: encoding-app
-    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/k8s-deployment/encoding-service/templates/encoding-secrets.yaml
+++ b/k8s-deployment/encoding-service/templates/encoding-secrets.yaml
@@ -1,6 +1,6 @@
 {{/* Define a few database URI variables */}}
 {{- $dbAddress := printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}
-{{- $dbURI := printf "postgresql://postgres:%s@%s:5432/postgres" .Values.postgresql.postgresPassword $dbAddress -}}
+{{- $dbURI := printf "postgresql://postgres:%s@%s:5432/postgres" .Values.global.postgresql.postgresqlPassword $dbAddress -}}
 {{- $brokerURI := printf "sqla+%s" $dbURI -}}
 apiVersion: v1
 kind: Secret
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "release_labels" . | indent 4 }}
 data:
-  postgresPassword: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  postgresPassword: {{ .Values.global.postgresql.postgresqlPassword | b64enc | quote }}
   databaseURI: {{ $dbURI | b64enc | quote }}
   brokerURI: {{ $brokerURI | b64enc | quote }}
 

--- a/k8s-deployment/encoding-service/templates/encoding-worker-deployment.yaml
+++ b/k8s-deployment/encoding-service/templates/encoding-worker-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.workers.replicas }}
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: encoding-worker
   template:
     metadata:

--- a/k8s-deployment/encoding-service/values.yaml
+++ b/k8s-deployment/encoding-service/values.yaml
@@ -19,13 +19,21 @@ app:
 service:
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ## Use ClusterIP if your setup includes an ingress controller.
-  type: "ClusterIP"
-  port: "80"
+  type: ClusterIP
+  servicePort: 80
 
-  ## Set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  annotations: {}
+
+  labels: {}
+
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
   # loadBalancerIP:
 
+  ## Address that are allowed when svc is LoadBalancer
+  ##
+  loadBalancerSourceRanges: []
 
 workers:
   image:
@@ -52,18 +60,22 @@ jobs:
       repository: "data61/anonlink-encoding-service"
       tag: "latest"
 
+global:
+  postgresql:
+    postgresqlDatabase: "postgres"
+    postgresqlUsername: "postgres"
+    postgresqlPassword: "secret"
 
 postgresql:
   # See available settings and defaults at:
-  # https://github.com/kubernetes/charts/tree/master/stable/postgresql
+  # https://github.com/bitnami/charts/tree/master/bitnami/postgresql
   nameOverride: "postgres"
-  postgresPassword: "secret"
+
   persistence:
     enabled: false
     storageClass: "default"
     size: 8Gi
-  imageTag: "9.6.2"
-  imagePullPolicy: IfNotPresent
+
   metrics:
     enabled: true
   resources:


### PR DESCRIPTION
- Make the k8s service configurable (added loadBalancerSourceRanges, annotations, and labels).
- Migrate off deprecated "stable" postgres chart to bitnami maintained one.
- Use standardized names for labels.
- Add chart's api version.

I've tested that the labels and annotations work.